### PR TITLE
Add failure tag for failed testcase, and changes on testcase's name

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ def create_testsuites():
 
 def append_testcases(prefix, testsuite):
     test_count = 0
-    failure_count = 0
+    testsuite_failure_count = 0
     csv_file_path = os.path.join(os.getcwd(), prefix + '_stats.csv')
 
     with open(csv_file_path, mode='r') as csv_file:
@@ -69,12 +69,20 @@ def append_testcases(prefix, testsuite):
                 testcase.set('name', name)
 
                 test_count += int(row['Request Count'])
-                failure_count += int(row['Failure Count'])
+                testcase.set('tests', str(test_count))
+                testcase_failure_count = int(row['Failure Count'])
+                testsuite_failure_count += testcase_failure_count
+                testcase.set('failures', str(testcase_failure_count))
+
+                if testcase_failure_count > 0:
+                    failure = ET.SubElement(testcase, 'failure')
+                    failure.set('message', '')
+
                 avg_response_s = float(row['Average Response Time']) / 1000
                 testcase.set('time', str(avg_response_s))
 
         testsuite.set('tests', str(test_count))
-        testsuite.set('failures', str(failure_count))
+        testsuite.set('failures', str(testsuite_failure_count))
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -48,6 +48,24 @@ def create_testsuites():
 
     return (testsuites, testsuite)
 
+def add_failure(prefix, testcase, request_method, request_name):
+    failure = ET.SubElement(testcase, 'failure')
+    csv_file_path = os.path.join(os.getcwd(), prefix + '_failures.csv')
+    failure_message = ''
+
+    with open(csv_file_path, mode='r') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+
+        for row in csv_reader:
+            row_method = row['Method']
+            row_name = row['Name']
+
+            if row_method == request_method and row_name == request_name:
+                failure_message = row['Error']
+                break
+
+    failure.set('message', failure_message)
+
 
 def append_testcases(prefix, testsuite):
     test_count = 0
@@ -72,8 +90,7 @@ def append_testcases(prefix, testsuite):
                 testcase.set('failures', str(testcase_failure_count))
 
                 if testcase_failure_count > 0:
-                    failure = ET.SubElement(testcase, 'failure')
-                    failure.set('message', '')
+                    add_failure(prefix, testcase, row_method, row_name)
 
                 avg_response_s = float(row['Average Response Time']) / 1000
                 testcase.set('time', str(avg_response_s))

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def main(argv):
     prefix = ''
 
     try:
-        opts, _ = getopt.getopt(sys.argv[1:], 'hp:', ['prefix='])
+        opts, _ = getopt.getopt(argv, 'hp:', ['prefix='])
     except getopt.GetoptError:
         print('main.py -p <prefix>')
         sys.exit(2)
@@ -30,7 +30,8 @@ def main(argv):
     append_testcases(prefix, testsuite)
 
     xml_tree = ET.ElementTree(testsuites)
-    xml_tree.write(os.getcwd() + '\\' + 'test_results.xml')
+    xml_file_path = os.path.join(os.getcwd(), 'test_results.xml')
+    xml_tree.write(xml_file_path)
 
 
 def create_testsuites():
@@ -51,29 +52,26 @@ def create_testsuites():
 def append_testcases(prefix, testsuite):
     test_count = 0
     failure_count = 0
+    csv_file_path = os.path.join(os.getcwd(), prefix + '_stats.csv')
 
-    with open(os.getcwd() + '\\' + prefix + '_stats.csv', mode='r') as csv_file:
+    with open(csv_file_path, mode='r') as csv_file:
         csv_reader = csv.DictReader(csv_file)
 
-        line_count = 0
         for row in csv_reader:
 
-            if line_count > 0:
-                row_method = row['Type']
-                row_name = row['Name']
+            row_method = row['Type']
+            row_name = row['Name']
 
-                if row_method != 'None' and row_name != 'Total':
-                    testcase = ET.SubElement(testsuite, 'testcase')
+            if row_method != '' and row_method != 'None' and row_name != 'Total':
+                testcase = ET.SubElement(testsuite, 'testcase')
 
-                    name = f'{row_method}\t{row_name} Average response time'
-                    testcase.set('name', name)
+                name = f'{row_method}: {row_name}'
+                testcase.set('name', name)
 
-                    test_count += int(row['Request Count'])
-                    failure_count += int(row['Failure Count'])
-                    avg_response_s = float(row['Average Response Time']) / 1000
-                    testcase.set('time', str(avg_response_s))
-
-            line_count += 1
+                test_count += int(row['Request Count'])
+                failure_count += int(row['Failure Count'])
+                avg_response_s = float(row['Average Response Time']) / 1000
+                testcase.set('time', str(avg_response_s))
 
         testsuite.set('tests', str(test_count))
         testsuite.set('failures', str(failure_count))

--- a/main_test.py
+++ b/main_test.py
@@ -44,13 +44,13 @@ class TestMain(unittest.TestCase):
 
   def test_conversion(self):
     self.assert_file('prefix1', [
-      'GET\t/ Average response time',
-      'GET\t/fail Average response time',
+      'GET: /',
+      'GET: /fail',
     ])
 
     self.assert_file('prefix2', [
-      'GET\t/ Average response time',
-      'GET\t/fail Average response time',
+      'GET: /',
+      'GET: /fail',
     ])
     return
 


### PR DESCRIPTION
Adds failure tag complete with failure's message  into failed testcase for fixing the produced report always reporting all tests is always succesful. 

But in these updates I've also changed produced testcase's name by replacing horizontal tab character with colon as separator between method and name. And also remove tailing 'Average response time' string from testcase name.
Which maybe out of your taste, or may break your existing use of this locust-csv-to-junit-xml.
So while I hope you would like to accept this, but it also would be understanable if you reject this updates.